### PR TITLE
chore(@biblical/web): webpack.prod

### DIFF
--- a/apps/web/webpack.prod.js
+++ b/apps/web/webpack.prod.js
@@ -8,8 +8,9 @@ module.exports = merge(common, {
   mode: 'production',
   plugins: [
     new BundleAnalyzerPlugin({
-      // analyzerMode:'static'
-      openAnalyzer: true,
+      analyzerMode: 'disabled',
+      openAnalyzer: false,
+      // openAnalyzer: true,
     }),
   ],
   optimization: {


### PR DESCRIPTION
## 🤔 Why need this change?

<!-- 변경한 이유에 대해서 설명해주세요 -->
### 문제
github action web build가 무한 진행중에 빠지고 완료가 안됨
- 잘 끝까지 빌드되다가 다음 단계로 안넘어감 에러 로그도 없음
![스크린샷 2023-09-20 오후 9 44 32](https://github.com/xmun74/biblical/assets/77045939/05535a32-c372-49d1-801b-6d8a2dde49b3)

### 원인
- webpack.prod에서 BundleAnalyzerPlugin openAnalyzer: true로 설정해 둔 것이 생각남
- 빌드 완료 후 서버시작하고 브라우저 열 수가 없어서 다음 단계로 넘어가지 않은 것

## 📝 Changes

<!-- 변경된 내용을 설명해주세요. -->

- webpack.prod에서 BundleAnalyzerPlugin openAnalyzer: false, analyzerMode: 'disabled'로 설정 변경

## 📌 Closed issue number

<!-- 해당 PR merge와 함께 관련된 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

closed #Issue_number

## 📸 Screenshot (optional)

## 📚 Reference (optional)

-
